### PR TITLE
Reduce candidate pool size to 10

### DIFF
--- a/docs/app.js
+++ b/docs/app.js
@@ -1,6 +1,6 @@
 // ========= 設定 =========
 const ROUNDS_PER_GAME = 3; // 1ゲームで抽選するラウンド数
-const TARGET_POOL_SIZE = 20; // 候補数：20
+const TARGET_POOL_SIZE = 10; // 候補数：10
 const COMMONS_CATEGORY = 'Category:360° panoramas with equirectangular projection'; // 取得元
 const COMMONS_API = 'https://commons.wikimedia.org/w/api.php';
 


### PR DESCRIPTION
## Summary
- set the target pool size constant to 10 so the app only retrieves ten candidates

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68dd35be53d883209197f9c8e0915d1e